### PR TITLE
Use first line of doc comment for help

### DIFF
--- a/auto-args-derive/src/lib.rs
+++ b/auto-args-derive/src/lib.rs
@@ -20,7 +20,7 @@ extern crate proc_macro2;
 use syn::*;
 
 fn get_doc_comment(attrs: &[syn::Attribute]) -> String {
-    let mut doc_comments: Vec<_> = attrs
+    let mut doc_comments = attrs
         .iter()
         .filter_map(|attr| {
             let path = &attr.path;
@@ -56,13 +56,9 @@ fn get_doc_comment(attrs: &[syn::Attribute]) -> String {
             } else {
                 None
             }
-        })
-        .collect();
-    if doc_comments.len() > 0 {
-        doc_comments.pop().unwrap_or("".to_string())
-    } else {
-        "".to_string()
-    }
+        });
+
+    doc_comments.next().unwrap_or_else(String::new)
 }
 
 fn return_with_fields(

--- a/src/guide.rs
+++ b/src/guide.rs
@@ -56,14 +56,14 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--foo]
+//!   create_guide-5214c7bad433b4e9  [--foo]
 //! 
 //! For more information try --help
 //! ```
 //! and the following help message.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--foo]
+//!   create_guide-5214c7bad433b4e9  [--foo]
 //! 
 //!   [--foo] 
 //! 
@@ -85,14 +85,14 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--verbose] [--T]
+//!   create_guide-5214c7bad433b4e9  [--verbose] [--T]
 //! 
 //! For more information try --help
 //! ```
 //! and the following help message.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--verbose] [--T]
+//!   create_guide-5214c7bad433b4e9  [--verbose] [--T]
 //! 
 //!   [--verbose] Print excess messages.
 //!   [--T]       The temperature.
@@ -120,7 +120,7 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--verbose] [--blue-is-nice-] [--min-T]
+//!   create_guide-5214c7bad433b4e9  [--verbose] [--blue-is-nice-] [--min-T]
 //! 
 //!   [--verbose]       a simple word has "--" prepended to it.
 //!   [--blue-is-nice-] Underscores are replaced with "-" ...
@@ -149,7 +149,7 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  --name STRING --T FLOAT --directory STRING
+//!   create_guide-5214c7bad433b4e9  --name STRING --T FLOAT --directory STRING
 //! 
 //!   --name STRING      The name of the type
 //!   --T FLOAT          The temperature of the type
@@ -183,7 +183,7 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545  [--name STRING]
+//!   create_guide-5214c7bad433b4e9  [--name STRING]
 //! 
 //!   [--name STRING] The name is an optional argument.
 //! 
@@ -201,9 +201,9 @@
 //!     First {
 //!         /// This is the "a" value
 //!         a: String,
+//!         /// Only the first line of comment shows up in help.
 //!         /// This is the "b" value, which you cannot specify unless
 //!         /// you also specify the "a" value.
-//!         /// Only one line of comment shows up in the help.
 //!         b: String,
 //!     },
 //!     /// A string that cannot be used with any other flag
@@ -215,18 +215,18 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545 (  --first-a STRING --first-b STRING | --second-flag STRING | --Third )
+//!   create_guide-5214c7bad433b4e9 (  --first-a STRING --first-b STRING | --second-flag STRING | --Third )
 //! 
 //! For more information try --help
 //! ```
 //! and the following help message.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545 (  --first-a STRING --first-b STRING | --second-flag STRING | --Third )
+//!   create_guide-5214c7bad433b4e9 (  --first-a STRING --first-b STRING | --second-flag STRING | --Third )
 //! 
 //!   EITHER               
 //!   --first-a STRING     This is the "a" value
-//!   --first-b STRING     Only one line of comment shows up in the help.
+//!   --first-b STRING     Only the first line of comment shows up in help.
 //!   OR                   
 //!   --second-flag STRING A string that cannot be used with any other flag
 //!   OR                   
@@ -276,7 +276,7 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545   --position-x FLOAT --position-y FLOAT  --velocity-x FLOAT --velocity-y FLOAT
+//!   create_guide-5214c7bad433b4e9   --position-x FLOAT --position-y FLOAT  --velocity-x FLOAT --velocity-y FLOAT
 //! 
 //!   --position-x FLOAT 
 //!   --position-y FLOAT 
@@ -315,14 +315,14 @@
 //! This gives the following usage.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545   --name STRING  --address STRING
+//!   create_guide-5214c7bad433b4e9   --name STRING  --address STRING
 //! 
 //! For more information try --help
 //! ```
 //! and the following help message.
 //! ```ignore
 //! USAGE:
-//!   create_guide-fb95975d41f6d545   --name STRING  --address STRING
+//!   create_guide-5214c7bad433b4e9   --name STRING  --address STRING
 //! 
 //!   --name STRING    The user's name
 //!   --address STRING The user's address

--- a/tests/create-guide.rs
+++ b/tests/create-guide.rs
@@ -187,9 +187,9 @@ fn guide() {
         First {
             /// This is the "a" value
             a: String,
+            /// Only the first line of comment shows up in help.
             /// This is the "b" value, which you cannot specify unless
             /// you also specify the "a" value.
-            /// Only one line of comment shows up in the help.
             b: String,
         },
         /// A string that cannot be used with any other flag

--- a/tests/doc-comment.rs
+++ b/tests/doc-comment.rs
@@ -1,0 +1,28 @@
+// Copyright 2018 David Roundy <roundyd@physics.oregonstate.edu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use auto_args::AutoArgs;
+
+#[test]
+fn simple_doc_comment() {
+    #[derive(AutoArgs, PartialEq, Debug)]
+    struct Opt {
+        /// First line
+        /// Second line
+        arg: u64,
+    }
+    println!("help: {}", Opt::help());
+    assert!(
+        Opt::help().contains("First line"),
+        "Should use the first line from the doc comment"
+    );
+    assert!(
+        !Opt::help().contains("Second line"),
+        "Should not use the second line from the doc comment"
+    );
+}


### PR DESCRIPTION
Hey,

Thanks for the library. I notice that the last line of the doc comment gets used for the help text, but I think it would make more sense if the first line was used. This works better with how doc comments are usually written i.e.

```
/// <summary>
///
/// <detailed description>
field: u64
```
